### PR TITLE
U14: Implement visual representation of map state with testing

### DIFF
--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -17,7 +17,7 @@ const config: Phaser.Types.Core.GameConfig = {
     width: ScreenWidth,
     height: ScreenHeight,
     parent: "game-container",
-    backgroundColor: "#black",
+    backgroundColor: "#0000FF",
     scene: [TitleScreen, LobbyScreen, GameScreen, GameUiScreen],
 };
 

--- a/src/managers/TileManager.ts
+++ b/src/managers/TileManager.ts
@@ -42,7 +42,6 @@ class TileManager {
         if (!this.list) {
             return null;
         }
-        assert(this.list);
         return this.list.filter(
             (tile: Tile) => tile.state === TileState.Placed,
         );

--- a/src/managers/TileManager.ts
+++ b/src/managers/TileManager.ts
@@ -38,6 +38,21 @@ class TileManager {
         );
     }
 
+    public getPlaced(): Nullable<Tile[]> {
+        let res: Nullable<Tile[]> = null;
+        if (!this.list) {
+            return res;
+        }
+        assert(this.list);
+        res = [];
+        this.list.forEach(function (tile) {
+            if (tile.state === TileState.Placed) {
+                res.push(tile);
+            }
+        });
+        return res;
+    }
+
     public initialize(): void {
         this.listen();
     }

--- a/src/managers/TileManager.ts
+++ b/src/managers/TileManager.ts
@@ -39,18 +39,13 @@ class TileManager {
     }
 
     public getPlaced(): Nullable<Tile[]> {
-        let res: Nullable<Tile[]> = null;
         if (!this.list) {
-            return res;
+            return null;
         }
         assert(this.list);
-        res = [];
-        this.list.forEach(function (tile) {
-            if (tile.state === TileState.Placed) {
-                res.push(tile);
-            }
-        });
-        return res;
+        return this.list.filter(
+            (tile: Tile) => tile.state === TileState.Placed,
+        );
     }
 
     public initialize(): void {

--- a/src/scenes/gamescreen.ts
+++ b/src/scenes/gamescreen.ts
@@ -12,7 +12,7 @@ import { assert, interactify } from "utilities/utils";
 export class GameScreen extends Phaser.Scene {
     private dragStart: Nullable<Phaser.Math.Vector2>;
     private placedTilesContainer: Nullable<Phaser.GameObjects.Container>;
-    static tilePixels: int = 128;
+    private static tilePixels: int = 128;
 
     private testingPlacedTiles: Nullable<Tile[]>; //test
     static testingCount: int = 1; //test
@@ -53,9 +53,6 @@ export class GameScreen extends Phaser.Scene {
         this.createCameraDrag();
         this.scene.launch("GameUiScreen");
         this.placedTilesContainer = this.add.container();
-        // test
-        const button: Phaser.GameObjects.Image = this.add.image(0, 0, "start");
-        interactify(button, 0.5, () => this.mockTileInfoChange());
     }
 
     /**

--- a/src/scenes/gamescreen.ts
+++ b/src/scenes/gamescreen.ts
@@ -81,11 +81,8 @@ export class GameScreen extends Phaser.Scene {
         const placedTiles: Nullable<Tile[]> = TileManager.getPlaced();
         assert(placedTiles);
         placedTiles.forEach((tile: Tile) => {
-            assert(
-                tile.coordinateX &&
-                    tile.coordinateY &&
-                    this.placedTilesContainer,
-            );
+            assert(tile.coordinateX && tile.coordinateY);
+            assert(this.placedTilesContainer);
             this.placedTilesContainer.add(
                 this.add.image(
                     tile.coordinateX * GameScreen.tilePixels,

--- a/src/scenes/gamescreen.ts
+++ b/src/scenes/gamescreen.ts
@@ -1,27 +1,19 @@
 import { ScreenHeight, ScreenWidth } from "core/main";
-import { SessionDTO } from "definitions/dto";
 import { Nullable, UUID, int } from "definitions/utils";
 import { Tile } from "entities/Tile";
-import GeneralManager from "managers/GeneralManager";
-import SessionManager from "managers/SessionManager";
 import TileManager from "managers/TileManager";
 import Phaser from "phaser";
-import seedrandom from "seedrandom";
-import { assert, interactify } from "utilities/utils";
+import { assert } from "utilities/utils";
 
 export class GameScreen extends Phaser.Scene {
     private dragStart: Nullable<Phaser.Math.Vector2>;
     private placedTilesContainer: Nullable<Phaser.GameObjects.Container>;
     private static tilePixels: int = 128;
 
-    private testingPlacedTiles: Nullable<Tile[]>; //test
-    static testingCount: int = 1; //test
-
     public constructor() {
         super("GameScreen");
         this.dragStart = null;
         this.placedTilesContainer = null;
-        this.testingPlacedTiles = null; //test
     }
 
     /**
@@ -96,33 +88,6 @@ export class GameScreen extends Phaser.Scene {
     }
 
     /**
-     * Mock function for testing purpose
-     *
-     * When clicking on the test button on top left corner, it simulates that a new tile is placed.\
-     * The tiles are placed one next to each other
-     *
-     * @returns nothing, but updates the local array that holds every placed tiles
-     */
-    private mockTileInfoChange(): void {
-        if (!this.testingPlacedTiles) {
-            this.testingPlacedTiles = [];
-        }
-        assert(this.testingPlacedTiles && SessionManager.get());
-        const session: Nullable<SessionDTO> = GeneralManager.getSession();
-        assert(session);
-        const random: seedrandom.PRNG = seedrandom(session.seed);
-        const newTile: Tile = new Tile(
-            random,
-            (GameScreen.testingCount - 1) % 9,
-        );
-        newTile.coordinateX = GameScreen.testingCount;
-        GameScreen.testingCount++;
-        newTile.coordinateY = 2;
-        this.testingPlacedTiles.push(newTile);
-        this.displayPlacedTiles();
-    }
-
-    /**
      * All tiles are kept in a placedTilesContainer.\
      * To update display, first remove all existing images, then create new ones using placed tiles from Tilemanager\
      *
@@ -136,12 +101,7 @@ export class GameScreen extends Phaser.Scene {
         assert(this.placedTilesContainer);
         this.placedTilesContainer.removeAll(true);
 
-        // official
         const placedTiles: Nullable<Tile[]> = TileManager.getPlaced();
-
-        // test - remove comment here and comment out line under //official
-        // const placedTiles: Nullable<Tile[]> = this.testingPlacedTiles;
-
         if (!placedTiles) {
             return;
         }

--- a/src/scenes/gamescreen.ts
+++ b/src/scenes/gamescreen.ts
@@ -16,19 +16,10 @@ export class GameScreen extends Phaser.Scene {
         this.placedTilesContainer = null;
     }
 
-    /**
-     * Gamescreen continuously listens to TileManager\
-     * Whenever there is a change in tile information, this means someone has made a move\
-     * Call displayPlacedTiles() to get updated view\
-     * The event listener is freed from memory on destroy scene event
-     *
-     * Can be extended to do more things when tile info changes
-     */
     public init(): void {
         const tileUpdateListener: UUID = TileManager.onSync.on(() => {
             this.displayPlacedTiles();
         });
-        // on scene destroy free listener
         this.events.on("destroy", () => {
             TileManager.onSync.off(tileUpdateListener);
         });
@@ -44,17 +35,13 @@ export class GameScreen extends Phaser.Scene {
         this.createWorld();
         this.createCameraDrag();
         this.scene.launch("GameUiScreen");
-        this.placedTilesContainer = this.add.container();
     }
 
-    /**
-     * Temporary: Create three tiles on top of screen that represent the goal tiles\
-     * Need to add starting tile and correct positioning
-     */
     private createWorld(): void {
         for (let i: int = 0; i < 3; i++) {
             this.add.image((2 + i * 2) * 128, 0, `tile${8}`);
         }
+        this.placedTilesContainer = this.add.container();
     }
 
     private createCameraDrag(): void {
@@ -87,33 +74,18 @@ export class GameScreen extends Phaser.Scene {
         this.dragStart = activePointer.position.clone();
     }
 
-    /**
-     * All tiles are kept in a placedTilesContainer.\
-     * To update display, first remove all existing images, then create new ones using placed tiles from Tilemanager\
-     *
-     * Whenever information about tiles is updated, it calls a list of placed tiles from TileManager
-     *
-     * Add the image at coordinate * pixels
-     *
-     * @returns void
-     */
     private displayPlacedTiles(): void {
         assert(this.placedTilesContainer);
         this.placedTilesContainer.removeAll(true);
 
         const placedTiles: Nullable<Tile[]> = TileManager.getPlaced();
-        if (!placedTiles) {
-            return;
-        }
         assert(placedTiles);
-        // this arrow function is only called in for loop, so should share same scope as displayedPlacedTiles()
-        placedTiles.forEach((tile) => {
+        placedTiles.forEach((tile: Tile) => {
             assert(
                 tile.coordinateX &&
                     tile.coordinateY &&
                     this.placedTilesContainer,
             );
-            // x, y coordinate correspond to the coordinate of the center of an image
             this.placedTilesContainer.add(
                 this.add.image(
                     tile.coordinateX * GameScreen.tilePixels,

--- a/src/scenes/gamescreen.ts
+++ b/src/scenes/gamescreen.ts
@@ -1,13 +1,45 @@
 import { ScreenHeight, ScreenWidth } from "core/main";
-import { Nullable, int } from "definitions/utils";
-import Phaser from "phaser";
+import { SessionDTO } from "definitions/dto";
+import { Nullable, UUID, int } from "definitions/utils";
+import { Tile } from "entities/Tile";
+import GeneralManager from "managers/GeneralManager";
+import SessionManager from "managers/SessionManager";
+import TileManager from "managers/TileManager";
+import Phaser, { Game } from "phaser";
+import seedrandom from "seedrandom";
+import { log } from "utilities/logger";
+import { assert, interactify } from "utilities/utils";
 
 export class GameScreen extends Phaser.Scene {
     private dragStart: Nullable<Phaser.Math.Vector2>;
+    private placedTilesContainer: Nullable<Phaser.GameObjects.Container>;
+    static tilePixels: int = 128;
+
+    private testingPlacedTiles: Nullable<Tile[]>; //test
+    static testingCount: int = 1; //test
 
     public constructor() {
         super("GameScreen");
         this.dragStart = null;
+        this.placedTilesContainer = null;
+        this.testingPlacedTiles = null; //test
+        GameScreen.tilePixels = 128;
+    }
+
+    /**
+     * Gamescreen continuously listens to TileManager\
+     * Whenever there is a change in tile information, this means someone has made a move\
+     * Call displayPlacedTiles() to get updated view\
+     * The event listener is freed from memory on destroy scene event
+     */
+    public init(): void {
+        const tileUpdateListener: UUID = TileManager.onSync.on(() =>
+            this.displayPlacedTiles(),
+        );
+        // on scene destroy free listener
+        this.events.on("destroy", () => {
+            TileManager.onSync.off(tileUpdateListener);
+        });
     }
 
     public preload(): void {
@@ -20,15 +52,19 @@ export class GameScreen extends Phaser.Scene {
         this.createWorld();
         this.createCameraDrag();
         this.scene.launch("GameUiScreen");
+        this.placedTilesContainer = this.add.container();
+        // test
+        const button: Phaser.GameObjects.Image = this.add.image(0, 0, "start");
+        interactify(button, 0.5, () => this.mockTileInfoChange());
     }
 
+    /**
+     * Temporary: Create three tiles on top of screen that represents the goal tiles\
+     * Need to add starting tile and correct positioning
+     */
     private createWorld(): void {
-        for (let i: int = 0; i < 9; i++) {
-            this.add.image(
-                Math.floor(Math.random() * 8) * 128,
-                Math.floor(Math.random() * 8) * 128,
-                `tile${i}`,
-            );
+        for (let i: int = 0; i < 3; i++) {
+            this.add.image((2 + i * 2) * 128, 0, `tile${8}`);
         }
     }
 
@@ -60,5 +96,74 @@ export class GameScreen extends Phaser.Scene {
             camera.scrollY += this.dragStart.y - activePointer.position.y;
         }
         this.dragStart = activePointer.position.clone();
+    }
+
+    /**
+     * Mock function for testing purpose
+     *
+     * When clicking on the test button on top left corner, it simulates that a new tile is placed.\
+     * The tiles are placed one next to each other
+     *
+     * @returns nothing, but updates the local array that holds every placed tiles
+     */
+    private mockTileInfoChange(): void {
+        if (!this.testingPlacedTiles) {
+            this.testingPlacedTiles = [];
+        }
+        assert(this.testingPlacedTiles && SessionManager.get());
+        const session: Nullable<SessionDTO> = GeneralManager.getSession();
+        assert(session);
+        const random: seedrandom.PRNG = seedrandom(session.seed);
+        const newTile: Tile = new Tile(
+            random,
+            (GameScreen.testingCount - 1) % 9,
+        );
+        newTile.coordinateX = GameScreen.testingCount;
+        GameScreen.testingCount++;
+        newTile.coordinateY = 3;
+        this.testingPlacedTiles.push(newTile);
+        this.displayPlacedTiles();
+    }
+
+    /**
+     * All tiles are kept in a placedTilesContainer.\
+     * To update display, first remove all existing images, then create new ones using placed tiles from Tilemanager\
+     *
+     * Whenever information about tiles is updated, it calls a list of placed tiles from TileManager
+     *
+     * Add the image at coordinate * pixels
+     *
+     * @returns void
+     */
+    private displayPlacedTiles(): void {
+        assert(this.placedTilesContainer);
+        this.placedTilesContainer.removeAll(true);
+
+        // official
+        // const placedTiles: Nullable<Tile[]> = TileManager.getPlaced();
+
+        // test
+        const placedTiles = this.testingPlacedTiles;
+
+        if (!placedTiles) {
+            return;
+        }
+        assert(placedTiles);
+        // this arrow function is only called in for loop, so should share same scope as displayedPlacedTiles()
+        placedTiles.forEach((tile) => {
+            assert(
+                tile.coordinateX &&
+                    tile.coordinateY &&
+                    this.placedTilesContainer,
+            );
+            // x, y coordinate correspond to the coordinate of the center of an image
+            this.placedTilesContainer.add(
+                this.add.image(
+                    tile.coordinateX * GameScreen.tilePixels,
+                    tile.coordinateY * GameScreen.tilePixels,
+                    `tile${tile.type}`,
+                ),
+            );
+        });
     }
 }

--- a/src/scenes/gamescreen.ts
+++ b/src/scenes/gamescreen.ts
@@ -5,9 +5,8 @@ import { Tile } from "entities/Tile";
 import GeneralManager from "managers/GeneralManager";
 import SessionManager from "managers/SessionManager";
 import TileManager from "managers/TileManager";
-import Phaser, { Game } from "phaser";
+import Phaser from "phaser";
 import seedrandom from "seedrandom";
-import { log } from "utilities/logger";
 import { assert, interactify } from "utilities/utils";
 
 export class GameScreen extends Phaser.Scene {
@@ -23,7 +22,6 @@ export class GameScreen extends Phaser.Scene {
         this.dragStart = null;
         this.placedTilesContainer = null;
         this.testingPlacedTiles = null; //test
-        GameScreen.tilePixels = 128;
     }
 
     /**
@@ -31,11 +29,13 @@ export class GameScreen extends Phaser.Scene {
      * Whenever there is a change in tile information, this means someone has made a move\
      * Call displayPlacedTiles() to get updated view\
      * The event listener is freed from memory on destroy scene event
+     *
+     * Can be extended to do more things when tile info changes
      */
     public init(): void {
-        const tileUpdateListener: UUID = TileManager.onSync.on(() =>
-            this.displayPlacedTiles(),
-        );
+        const tileUpdateListener: UUID = TileManager.onSync.on(() => {
+            this.displayPlacedTiles();
+        });
         // on scene destroy free listener
         this.events.on("destroy", () => {
             TileManager.onSync.off(tileUpdateListener);
@@ -59,7 +59,7 @@ export class GameScreen extends Phaser.Scene {
     }
 
     /**
-     * Temporary: Create three tiles on top of screen that represents the goal tiles\
+     * Temporary: Create three tiles on top of screen that represent the goal tiles\
      * Need to add starting tile and correct positioning
      */
     private createWorld(): void {
@@ -120,7 +120,7 @@ export class GameScreen extends Phaser.Scene {
         );
         newTile.coordinateX = GameScreen.testingCount;
         GameScreen.testingCount++;
-        newTile.coordinateY = 3;
+        newTile.coordinateY = 2;
         this.testingPlacedTiles.push(newTile);
         this.displayPlacedTiles();
     }
@@ -140,10 +140,10 @@ export class GameScreen extends Phaser.Scene {
         this.placedTilesContainer.removeAll(true);
 
         // official
-        // const placedTiles: Nullable<Tile[]> = TileManager.getPlaced();
+        const placedTiles: Nullable<Tile[]> = TileManager.getPlaced();
 
-        // test
-        const placedTiles = this.testingPlacedTiles;
+        // test - remove comment here and comment out line under //official
+        // const placedTiles: Nullable<Tile[]> = this.testingPlacedTiles;
 
         if (!placedTiles) {
             return;


### PR DESCRIPTION
Implement visual representation of placed tiles

Set a listener to TileManager, on change to any tile information, call displayPlacedTiles()

The images are kept in a container. When a new call happens, clear the container and add all placed tiles back to container. (Like playnames in lobby)

Add getPlaced() method in TileManager

This PR contains testing code.