### PR TITLE
Clean up sprint 2: Display join error

### DIFF
--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -88,7 +88,6 @@ class SessionManager {
         } catch (error) {
             if (axios.isAxiosError(error) && error.response?.status) {
                 PlayerManager.delete();
-                return;
             }
             location.pathname = "";
             return;

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -84,14 +84,12 @@ class SessionManager {
                 requestBody,
             );
             PlayerManager.saveId(response.data);
-            location.pathname = "";
         } catch (error) {
             if (axios.isAxiosError(error) && error.response?.status) {
                 PlayerManager.delete();
             }
-            location.pathname = "";
-            return;
         }
+        location.pathname = "";
     }
 
     private listen(): void {

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -87,7 +87,6 @@ class SessionManager {
             location.pathname = "";
         } catch (error) {
             if (axios.isAxiosError(error) && error.response?.status) {
-                alert(error.response?.data.message);
                 PlayerManager.delete();
                 return;
             }

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -89,10 +89,9 @@ class SessionManager {
             if (axios.isAxiosError(error) && error.response?.status) {
                 alert(error.response?.data.message);
                 PlayerManager.delete();
-                location.pathname = "";
                 return;
             }
-            alert("Unexpected error when joining game. Please try again.");
+            location.pathname = "";
             return;
         }
     }

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -84,11 +84,7 @@ class SessionManager {
                 requestBody,
             );
             PlayerManager.saveId(response.data);
-        } catch (error) {
-            if (axios.isAxiosError(error) && error.response?.status) {
-                PlayerManager.delete();
-            }
-        }
+        } catch (error) {}
         location.pathname = "";
     }
 

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -89,6 +89,7 @@ class SessionManager {
             if (axios.isAxiosError(error) && error.response?.status) {
                 alert(error.response?.data.message);
                 PlayerManager.delete();
+                location.pathname = "";
                 return;
             }
             alert("Unexpected error when joining game. Please try again.");

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -1,6 +1,6 @@
 import { int, Nullable, UUID } from "definitions/utils";
 import PlayerManager from "../managers/PlayerManager";
-import axios, { AxiosError } from "axios";
+import axios from "axios";
 import { api } from "../utilities/api";
 import { JoinDTO, SessionDTO } from "definitions/dto";
 import GeneralManager from "./GeneralManager";
@@ -8,8 +8,6 @@ import { assert } from "utilities/utils";
 import { Session } from "entities/Session";
 import { EventEmitter } from "utilities/EventEmitter";
 import { Player } from "../entities/Player";
-import { log } from "utilities/logger";
-import { StartGame } from "core/main";
 
 class SessionManager {
     public readonly onSync: EventEmitter;
@@ -89,7 +87,6 @@ class SessionManager {
             location.pathname = "";
         } catch (error) {
             if (axios.isAxiosError(error) && error.response?.status) {
-                log(error);
                 alert(error.response?.data.message);
                 PlayerManager.delete();
                 return;


### PR DESCRIPTION
When a user now tries to join a started session, the client will display an alert pop up with error message from server.

Then client automatically redirects to title screen. The user can continue creating session and play as normal.

Tested with different browser single player, different browser multi player and same browser after deleting playerID in local storage. All three cases displays a pop-up, redirect to titlescreen and create session works just fine.